### PR TITLE
Replace usage of syscall.Mkfifo with unix.Mkfifo.

### DIFF
--- a/fifo.go
+++ b/fifo.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 type fifo struct {
@@ -38,7 +39,7 @@ var leakCheckWg *sync.WaitGroup
 func OpenFifo(ctx context.Context, fn string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
 	if _, err := os.Stat(fn); err != nil {
 		if os.IsNotExist(err) && flag&syscall.O_CREAT != 0 {
-			if err := syscall.Mkfifo(fn, uint32(perm&os.ModePerm)); err != nil && !os.IsExist(err) {
+			if err := unix.Mkfifo(fn, uint32(perm&os.ModePerm)); err != nil && !os.IsExist(err) {
 				return nil, errors.Wrapf(err, "error creating fifo %v", fn)
 			}
 		} else {


### PR DESCRIPTION
This is a requirement for the Solaris platform.
ping @tonistiigi 

Signed-off-by: Amit Krishnan <krish.amit@gmail.com>