### PR TITLE
Use uint64() when initializing handle.dev from syscall.Stat_t.Dev.

### DIFF
--- a/handle_linux.go
+++ b/handle_linux.go
@@ -36,7 +36,7 @@ func getHandle(fn string) (*handle, error) {
 	h := &handle{
 		f:    f,
 		name: fn,
-		dev:  stat.Dev,
+		dev:  uint64(stat.Dev),
 		ino:  stat.Ino,
 	}
 
@@ -62,7 +62,7 @@ func (h *handle) Path() (string, error) {
 	if err := syscall.Stat(h.procPath(), &stat); err != nil {
 		return "", errors.Wrapf(err, "path %v could not be statted", h.procPath())
 	}
-	if stat.Dev != h.dev || stat.Ino != h.ino {
+	if uint64(stat.Dev) != h.dev || stat.Ino != h.ino {
 		return "", errors.Errorf("failed to verify handle %v/%v %v/%v", stat.Dev, h.dev, stat.Ino, h.ino)
 	}
 	return h.procPath(), nil


### PR DESCRIPTION
On some architectures (mips, mips64) syscall.Stat_t.Dev is uint32.
Btw, this is the only change required for this package to get built for
GOARCH=mips/mipsle/mips64/mips64le.